### PR TITLE
[173, 175] - Fix rate button (Rate Fixes) and Sprint 9 BugFixes

### DIFF
--- a/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.html
@@ -41,12 +41,7 @@
                                 </a>
                             </p>
                             <p class="auction__description">
-                                {{ auction.description | slice : 0 : 150 }}
-                                {{
-                                    auction.description.length > 150
-                                        ? '...'
-                                        : ''
-                                }}
+                                {{ auction.description }}
                             </p>
                         </div>
                         <div class="auction__price">

--- a/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.scss
@@ -68,6 +68,7 @@
 
     &__auction-no-more {
         font-size: 18px;
+        margin: 0 auto;
     }
 
     &__auction-empty {
@@ -259,8 +260,12 @@
     }
 
     &__description {
-        display: block;
-        word-break: break-word;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+
         max-width: 40ch;
         color: var(--color-grey-3);
     }
@@ -335,6 +340,10 @@
         border-radius: 8px;
         size: 16px;
     }
+}
+
+.show-more {
+    margin: 0 auto;
 }
 
 .show-more-button {

--- a/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/buyer/dashboard/dashboard.component.ts
@@ -30,7 +30,7 @@ export class DashboardComponent implements OnInit {
     userProfileData: BuyerModel | null = null;
     senderRates: Rate[] = [];
     IsBtnVisible: boolean = true;
-    IsSentRates: boolean = false;
+    IsSentRates: boolean = true;
 
     priceColor: string = 'black';
 

--- a/src/Auctionify.API/ClientApp/src/app/components/general/home/auction/auction.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/home/auction/auction.component.html
@@ -15,7 +15,13 @@
     <mat-icon class="primary">favorite_border</mat-icon>
 </ng-template>
 <div class="main">
-    <div class="main__container">
+    <div class="main__container" *ngIf="activeLots$ | async as activeLots">
+        <div
+            class="main__auction-active-title"
+            *ngIf="activeLots && activeLots.length > 0"
+        >
+            <h2>Active auctions</h2>
+        </div>
         <div class="main__auction-active">
             <div class="lot" *ngFor="let lot of activeLots$ | async">
                 <div class="lot__image">

--- a/src/Auctionify.API/ClientApp/src/app/components/general/home/auction/auction.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/home/auction/auction.component.scss
@@ -3,7 +3,6 @@
     margin: 0 auto;
     justify-content: flex-end;
     align-items: center;
-    margin-bottom: 24px;
 
     &__btns-right {
         display: flex;
@@ -53,6 +52,15 @@
         flex-direction: column;
     }
 
+    &__btn {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 24px;
+        padding-bottom: 20px;
+    }
+
     &__auction-active {
         display: flex;
         flex-wrap: wrap;
@@ -61,13 +69,12 @@
         gap: 8px;
     }
 
-    &__btn {
+    &__auction-active-title {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        gap: 24px;
-        padding-bottom: 20px;
+        width: 100%;
+        justify-content: flex-start;
+        padding-top: 30px;
+        padding-bottom: 30px;
     }
 
     &__auction-upcoming {

--- a/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.html
@@ -328,32 +328,84 @@
                 </ul>
             </div>
         </div>
-        <div class="right__rate-btn" *ngIf="canSellerRateBuyer">
-            <button
-                [routerLink]="['/rate-user', lotData.id]"
-                class="mat-mdc-outlined-button-custom price-button"
-                mat-flat-button
-                type="button"
-                color="primary"
+        <ng-container *ngIf="!userOwnRate; else userOwnRateExist">
+            <div class="right__rate-btn" *ngIf="canSellerRateBuyer">
+                <button
+                    [routerLink]="['/rate-user', lotData.id]"
+                    class="mat-mdc-outlined-button-custom price-button"
+                    mat-flat-button
+                    type="button"
+                    color="primary"
+                >
+                    <mat-icon>star_border</mat-icon>
+                    Rate
+                </button>
+            </div>
+            <div
+                class="right__rate-btn"
+                *ngIf="isUserBuyer() && canBuyerRateSeller"
             >
-                <mat-icon>star_border</mat-icon>
-                Rate
-            </button>
-        </div>
-        <div
-            class="right__rate-btn"
-            *ngIf="isUserBuyer() && canBuyerRateSeller"
-        >
-            <button
-                [routerLink]="['/rate-user', lotData.id]"
-                class="mat-mdc-outlined-button-custom price-button"
-                mat-flat-button
-                type="button"
-                color="primary"
-            >
-                Rate
-                <mat-icon>star_border</mat-icon>
-            </button>
-        </div>
+                <button
+                    [routerLink]="['/rate-user', lotData.id]"
+                    class="mat-mdc-outlined-button-custom price-button"
+                    mat-flat-button
+                    type="button"
+                    color="primary"
+                >
+                    Rate
+                    <mat-icon>star_border</mat-icon>
+                </button>
+            </div>
+        </ng-container>
     </div>
+
+    <ng-template #userOwnRateExist>
+        <p class="my-rate-title">My rate for this auction</p>
+        <div class="rate" (click)="onRateClick()">
+            <div class="rate__profile-img">
+                <img
+                    [src]="
+                        this.userOwnRate?.sender?.profilePicture ||
+                        '../../../../../assets/images/User.png'
+                    "
+                    alt="rate-user-profile-pic"
+                    width="48"
+                    height="48"
+                />
+            </div>
+            <div class="rate__data">
+                <div class="rate__name-date-value">
+                    <div class="rate__name-date">
+                        <div class="rate__name">
+                            <p>
+                                {{ this.userOwnRate?.sender?.firstName }}
+                                {{ this.userOwnRate?.sender?.lastName }}
+                            </p>
+                        </div>
+
+                        <div class="rate__date">
+                            <p>
+                                {{
+                                    formatDate(this.userOwnRate!.creationDate!)
+                                }}
+                            </p>
+                        </div>
+                    </div>
+                    <div class="rate__stars">
+                        <mat-icon
+                            *ngFor="
+                                let star of getStars(
+                                    this.userOwnRate?.ratingValue!
+                                )
+                            "
+                            >{{ star }}</mat-icon
+                        >
+                    </div>
+                </div>
+                <div class="rate__comment">
+                    <p>{{ this.userOwnRate?.comment }}</p>
+                </div>
+            </div>
+        </div>
+    </ng-template>
 </div>

--- a/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.html
@@ -336,8 +336,8 @@
                 type="button"
                 color="primary"
             >
-                <mat-icon>edit</mat-icon>
-                rate
+                <mat-icon>star_border</mat-icon>
+                Rate
             </button>
         </div>
         <div
@@ -351,8 +351,8 @@
                 type="button"
                 color="primary"
             >
-                <mat-icon>edit</mat-icon>
-                rate
+                Rate
+                <mat-icon>star_border</mat-icon>
             </button>
         </div>
     </div>

--- a/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.scss
@@ -421,3 +421,67 @@
         flex-wrap: wrap-reverse;
     }
 }
+
+.my-rate-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 10px;
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 24px;
+    letter-spacing: 0em;
+    text-align: left;
+}
+
+.rate {
+    display: flex;
+    gap: 16px;
+    border-radius: 10px;
+    padding: 10px;
+    padding-left: 20px;
+    margin-top: -15px;
+    cursor: pointer;
+
+    &__profile-img img {
+        border-radius: 500px;
+        object-fit: cover;
+    }
+
+    &__data {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    &__name-date-value {
+        display: flex;
+        gap: 24px;
+        align-items: flex-start;
+    }
+
+    &__name-date {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    &__name {
+        font-size: 18px;
+    }
+
+    &__date {
+        font-size: 14px;
+        color: #828282;
+    }
+
+    &__stars mat-icon {
+        color: #ffc72c;
+    }
+
+    &:hover {
+        background-color: #ffffffdb;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+        transition: box-shadow 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+    }
+}

--- a/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.scss
@@ -406,7 +406,13 @@
     }
 
     &__rate-btn {
-        width: 100px;
+        width: 110px;
+
+        & mat-icon {
+            font-size: 25px;
+            width: 25px;
+            height: 25px;
+        }
     }
 }
 

--- a/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/lot-profile/lot-profile.component.ts
@@ -23,6 +23,7 @@ import { AddBidComponent } from '../add-bid/add-bid.component';
 import { WithdrawBidComponent } from '../withdraw-bid/withdraw-bid.component';
 import { RemoveFromWatchlistComponent } from '../remove-from-watchlist/remove-from-watchlist.component';
 import { UserDataValidatorService } from 'src/app/services/user-data-validator/user-data-validator.service';
+import { Rate } from 'src/app/models/rates/rate-models';
 
 @Component({
     selector: 'app-lot-profile',
@@ -43,6 +44,7 @@ export class LotProfileComponent implements OnInit {
     soldLotStatus: string = 'Sold';
     canBuyerRateSeller: boolean = false;
     canSellerRateBuyer: boolean = false;
+    userOwnRate: Rate | null = null;
 
     private isSignalrConnected = false;
 
@@ -64,6 +66,7 @@ export class LotProfileComponent implements OnInit {
 
     ngOnInit() {
         this.getLotFromRoute();
+        this.getUserOwnRateLot(this.lotId);
     }
 
     getLotFromRoute() {
@@ -343,7 +346,6 @@ export class LotProfileComponent implements OnInit {
     }
 
     canSellerRate(): void {
-        console.log(this.lotData);
         if (
             this.currentUserId == this.lotData?.sellerId &&
             this.lotData?.lotStatus.name == this.soldLotStatus
@@ -378,5 +380,35 @@ export class LotProfileComponent implements OnInit {
 
     ngOnDestroy() {
         this.signalRService.leaveLotGroup(this.lotId);
+    }
+
+    getUserOwnRateLot(lotId: number): Rate {
+        this.client.getUserOwnRateLot(lotId).subscribe({
+            next: (result) => {
+                this.userOwnRate = result;
+                console.log(this.userOwnRate);
+            },
+        });
+        return this.userOwnRate!;
+    }
+
+    formatDate(date: Date | null): string {
+        return date ? formatDate(date, 'HH:mm, MMMM d, y', 'en-US') : '';
+    }
+
+    getStars(count: number): string[] {
+        const stars: string[] = [];
+        for (let i = 1; i <= 5; i++) {
+            if (i <= count) {
+                stars.push('star');
+            } else {
+                stars.push('star_border');
+            }
+        }
+        return stars;
+    }
+
+    onRateClick() {
+        this.router.navigate([`profile/user/${this.userOwnRate?.senderId}`]);
     }
 }

--- a/src/Auctionify.API/ClientApp/src/app/components/general/rate-user/rate-user.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/rate-user/rate-user.component.html
@@ -26,7 +26,8 @@
                 <h1>Describe your feelings</h1>
             </div>
             <div class="main__rate-stars">
-                <p>How would you rate the seller?</p>
+                <p *ngIf="isUserSeller()">How would you rate the buyer?</p>
+                <p *ngIf="isUserBuyer()">How would you rate the seller?</p>
                 <div class="main__stars">
                     <mat-icon
                         *ngFor="let star of [1, 2, 3, 4, 5]"

--- a/src/Auctionify.API/ClientApp/src/app/components/general/rate-user/rate-user.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/rate-user/rate-user.component.ts
@@ -70,7 +70,7 @@ export class RateUserComponent implements OnInit {
                     this.errorMessage = '';
                     this.showSnackBar('Rate submitted successfully', 'success');
                     this.isLoading = false;
-                    this.router.navigate(['/home']);
+                    this.router.navigate(['/get-lot', this.lotId]);
                 },
                 error: (error) => {
                     if (
@@ -90,7 +90,7 @@ export class RateUserComponent implements OnInit {
                     this.errorMessage = '';
                     this.showSnackBar('Rate submitted successfully', 'success');
                     this.isLoading = false;
-                    this.router.navigate(['/home']);
+                    this.router.navigate(['/get-lot', this.lotId]);
                 },
                 error: (error) => {
                     if (
@@ -149,5 +149,9 @@ export class RateUserComponent implements OnInit {
 
     isUserSeller(): boolean {
         return this.authorizeService.isUserSeller();
+    }
+
+    isUserBuyer(): boolean {
+        return this.authorizeService.isUserBuyer();
     }
 }

--- a/src/Auctionify.API/ClientApp/src/app/components/general/rate/feedback/feedback.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/general/rate/feedback/feedback.component.ts
@@ -112,8 +112,4 @@ export class FeedbackComponent {
     isUserBuyer(): boolean {
         return this.authorizeService.isUserBuyer();
     }
-
-    formatDate(date: Date | null): string {
-        return date ? formatDate(date, 'dd LLLL, h:mm', 'en-US') : '';
-    }
 }

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.ts
@@ -16,7 +16,7 @@ export class DashboardComponent implements OnInit {
     userProfileData: SellerModel | null = null;
     senderRates: Rate[] = [];
     IsBtnVisible: boolean = true;
-    IsSentRates: boolean = false;
+    IsSentRates: boolean = true;
 
     constructor(
         private client: Client,

--- a/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.html
@@ -2,9 +2,9 @@
     <div class="review__profile-img">
         <img
             [src]="
-                rate.sender && rate.sender.profilePicture
-                    ? rate.sender.profilePicture
-                    : '../../../../../assets/images/User.png'
+                rate.sender?.profilePicture ||
+                rate.receiver?.profilePicture ||
+                '../../../../../assets/images/User.png'
             "
             alt="rate-user-profile-pic"
             width="48"
@@ -15,8 +15,13 @@
         <div class="review__name-date-value">
             <div class="review__name-date">
                 <div class="review__name">
-                    <p>
-                        {{ rate.sender?.firstName }} {{ rate.sender?.lastName }}
+                    <p *ngIf="IsSentRates">
+                        {{ rate.sender?.firstName }}
+                        {{ rate.sender?.lastName }}
+                    </p>
+                    <p *ngIf="!IsSentRates">
+                        {{ rate.receiver?.firstName }}
+                        {{ rate.receiver?.lastName }}
                     </p>
                 </div>
                 <div class="review__date">

--- a/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.scss
@@ -1,6 +1,9 @@
 .review {
     display: flex;
     gap: 16px;
+    border-radius: 10px;
+    padding: 10px;
+    cursor: pointer;
 
     &__profile-img img {
         border-radius: 500px;
@@ -38,5 +41,9 @@
         color: #ffc72c;
     }
 
-    cursor: pointer;
+    &:hover {
+        background-color: #ffffffdb;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+        transition: box-shadow 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+    }
 }

--- a/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.scss
@@ -37,4 +37,6 @@
     &__stars mat-icon {
         color: #ffc72c;
     }
+
+    cursor: pointer;
 }

--- a/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/ui-elements/rate-item/rate-item.component.ts
@@ -26,7 +26,7 @@ export class RateItemComponent {
     }
 
     formatDate(date: Date | null): string {
-        return date ? formatDate(date, 'dd LLLL, h:mm', 'en-US') : '';
+        return date ? formatDate(date, 'HH:mm, MMMM d, y', 'en-US') : '';
     }
 
     getStars(count: number): string[] {

--- a/src/Auctionify.API/ClientApp/src/app/web-api-client.ts
+++ b/src/Auctionify.API/ClientApp/src/app/web-api-client.ts
@@ -421,6 +421,24 @@ export class Client {
         );
     }
 
+    getUserOwnRateLot(lotId: number): Observable<Rate> {
+        let url_ = this.baseUrl + `/api/rates/senders/${lotId}`;
+
+        let options_: any = {
+            observe: 'response',
+            headers: new HttpHeaders({
+                'Content-Type': 'application/json',
+                Accept: 'text/json',
+            }),
+        };
+
+        return this.http.request('get', url_, options_).pipe(
+            map((response: any): Rate => {
+                return response.body;
+            })
+        );
+    }
+
     deleteLotFile(id: number, url: string): Observable<any> {
         let url_ = this.baseUrl + `/api/lots/${id}/files`;
 

--- a/src/Auctionify.API/Controllers/RatesController.cs
+++ b/src/Auctionify.API/Controllers/RatesController.cs
@@ -1,8 +1,9 @@
 ﻿using Auctionify.Application.Common.Models.Requests;
-using Auctionify.Application.Features.Rates.Queries.GetReceiverRates;
-using Auctionify.Application.Features.Rates.Queries.GetSenderRates;
 using Auctionify.Application.Features.Rates.Commands.AddRateToBuyer;
 using Auctionify.Application.Features.Rates.Commands.AddRateToSeller;
+using Auctionify.Application.Features.Rates.Queries.GetReceiverRates;
+using Auctionify.Application.Features.Rates.Queries.GetSenderRate;
+using Auctionify.Application.Features.Rates.Queries.GetSenderRates;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -59,5 +60,15 @@ namespace Auctionify.API.Controllers
 			var result = await _mediator.Send(query);
 			return Ok(result);
 		}
+
+		[HttpGet("senders/{lotId}")]
+		[Authorize(Roles = "Buyer, Seller")]
+		public async Task<IActionResult> GetSenderRate(int lotId)
+		{
+			var query = new GetSenderRateQuery { LotId = lotId };
+			var result = await _mediator.Send(query);
+			return Ok(result);
+		}
+
 	}
 }

--- a/src/Auctionify.Application/Features/Lots/Queries/GetByIdForBuyer/GetByIdForBuyerLotQuery.cs
+++ b/src/Auctionify.Application/Features/Lots/Queries/GetByIdForBuyer/GetByIdForBuyerLotQuery.cs
@@ -62,7 +62,8 @@ namespace Auctionify.Application.Features.Lots.Queries.GetByIdForBuyer
 						.Include(x => x.Currency)
 						.Include(x => x.Location)
 						.Include(x => x.LotStatus)
-						.Include(x => x.Bids),
+						.Include(x => x.Bids)
+						.Include(x => x.Seller),
 				cancellationToken: cancellationToken
 			);
 
@@ -126,6 +127,8 @@ namespace Auctionify.Application.Features.Lots.Queries.GetByIdForBuyer
 				result.PhotosUrl = photoLinks;
 				result.AdditionalDocumentsUrl = additionalDocumentLinks;
 
+				result.SellerEmail = lot.Seller.Email;
+
 				var profilePictureName = user.ProfilePicture;
 
 				if (user.ProfilePicture != null)
@@ -134,9 +137,8 @@ namespace Auctionify.Application.Features.Lots.Queries.GetByIdForBuyer
 						_azureBlobStorageOptions.UserProfilePhotosFolderName,
 						profilePictureName
 					);
-					
+
 					result.ProfilePictureUrl = profilePictureUrl;
-					
 				}
 			}
 			else

--- a/src/Auctionify.Application/Features/Lots/Queries/GetByIdForSeller/GetByIdForSellerLotQuery.cs
+++ b/src/Auctionify.Application/Features/Lots/Queries/GetByIdForSeller/GetByIdForSellerLotQuery.cs
@@ -4,7 +4,6 @@ using Auctionify.Application.Common.Interfaces.Repositories;
 using Auctionify.Application.Common.Options;
 using Auctionify.Core.Entities;
 using AutoMapper;
-using Azure;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
@@ -126,7 +125,7 @@ namespace Auctionify.Application.Features.Lots.Queries.GetByIdForSeller
 						_azureBlobStorageOptions.UserProfilePhotosFolderName,
 						profilePictureName
 					);
-					
+
 					result.ProfilePictureUrl = profilePictureUrl;
 				}
 			}

--- a/src/Auctionify.Application/Features/Rates/Commands/AddRateToBuyer/AddRateToBuyerCommandValidator.cs
+++ b/src/Auctionify.Application/Features/Rates/Commands/AddRateToBuyer/AddRateToBuyerCommandValidator.cs
@@ -1,29 +1,26 @@
 ﻿using Auctionify.Application.Common.Interfaces.Repositories;
-using Auctionify.Core.Entities;
 using Auctionify.Core.Enums;
-using AutoMapper;
 using FluentValidation;
-using Microsoft.AspNetCore.Identity;
 
 namespace Auctionify.Application.Features.Rates.Commands.AddRateToBuyer
 {
-    public class AddRateToBuyerCommandValidator : AbstractValidator<AddRateToBuyerCommand>
-    {
-        private readonly IRateRepository _rateRepository;
-        private readonly ILotRepository _lotRepository;
-        private readonly ILotStatusRepository _lotStatusRepository;
+	public class AddRateToBuyerCommandValidator : AbstractValidator<AddRateToBuyerCommand>
+	{
+		private readonly IRateRepository _rateRepository;
+		private readonly ILotRepository _lotRepository;
+		private readonly ILotStatusRepository _lotStatusRepository;
 
-        public AddRateToBuyerCommandValidator(
-            IRateRepository rateRepository,
-            ILotRepository lotRepository,
-            ILotStatusRepository lotStatusRepository
-        )
-        {
-            _rateRepository = rateRepository;
-            _lotRepository = lotRepository;
-            _lotStatusRepository = lotStatusRepository;
+		public AddRateToBuyerCommandValidator(
+			IRateRepository rateRepository,
+			ILotRepository lotRepository,
+			ILotStatusRepository lotStatusRepository
+		)
+		{
+			_rateRepository = rateRepository;
+			_lotRepository = lotRepository;
+			_lotStatusRepository = lotStatusRepository;
 
-            ClassLevelCascadeMode = CascadeMode.Stop;
+			ClassLevelCascadeMode = CascadeMode.Stop;
 
 			RuleFor(x => x.LotId)
 				.Cascade(CascadeMode.Stop)
@@ -43,58 +40,58 @@ namespace Auctionify.Application.Features.Rates.Commands.AddRateToBuyer
 				.WithName("Lot Id");
 
 			RuleFor(x => x.LotId)
-                .Cascade(CascadeMode.Stop)
-                .MustAsync(
-                    async (lotId, cancellationToken) =>
-                    {
-                        var lot = await _lotRepository.GetAsync(
-                            predicate: x => x.Id == lotId,
-                            cancellationToken: cancellationToken
-                        );
+				.Cascade(CascadeMode.Stop)
+				.MustAsync(
+					async (lotId, cancellationToken) =>
+					{
+						var lot = await _lotRepository.GetAsync(
+							predicate: x => x.Id == lotId,
+							cancellationToken: cancellationToken
+						);
 
-                        var lotStatus = await _lotStatusRepository.GetAsync(
-                            predicate: x => x.Name == AuctionStatus.Sold.ToString(),
-                            cancellationToken: cancellationToken
-                        );
+						var lotStatus = await _lotStatusRepository.GetAsync(
+							predicate: x => x.Name == AuctionStatus.Sold.ToString(),
+							cancellationToken: cancellationToken
+						);
 
-                        if (lot is not null && lotStatus is not null)
-                        {
-                            return lot.LotStatusId == lotStatus.Id;
-                        }
+						if (lot is not null && lotStatus is not null)
+						{
+							return lot.LotStatusId == lotStatus.Id;
+						}
 
-                        return false;
-                    }
-                )
-                .WithMessage("You can rate if the lot will be sold to you")
-                .OverridePropertyName("LotId")
-                .WithName("Lot Id");
+						return false;
+					}
+				)
+				.WithMessage("You can rate if the lot will be sold to you")
+				.OverridePropertyName("LotId")
+				.WithName("Lot Id");
 
-            RuleFor(x => x)
-                .Cascade(CascadeMode.Stop)
-                .MustAsync(
-                    async (request, cancellationToken) =>
-                    {
-                        var lot = await _lotRepository.GetAsync(
-                            predicate: x => x.Id == request.LotId,
-                            cancellationToken: cancellationToken
-                        );
+			RuleFor(x => x)
+				.Cascade(CascadeMode.Stop)
+				.MustAsync(
+					async (request, cancellationToken) =>
+					{
+						var lot = await _lotRepository.GetAsync(
+							predicate: x => x.Id == request.LotId,
+							cancellationToken: cancellationToken
+						);
 
 						var ratings = await _rateRepository.GetListAsync(
 								predicate: l => l.LotId == request.LotId,
 								cancellationToken: cancellationToken
 						);
 
-						if (ratings.Items.Count < 1 && !ratings.Items.Any(item => item.SenderId == lot.SellerId))
+						if (ratings.Items.Count <= 2 && !ratings.Items.Any(item => item.SenderId == lot.SellerId))
 						{
-                            return true;
+							return true;
 						}
 
 						return false;
-                    }
-                )
-                .WithMessage("You have already rate")
-                .OverridePropertyName("Rate")
-                .WithName("Rate");
-        }
-    }
+					}
+				)
+				.WithMessage("You have already rated")
+				.OverridePropertyName("Rate")
+				.WithName("Rate");
+		}
+	}
 }

--- a/src/Auctionify.Application/Features/Rates/Commands/AddRateToSeller/AddRateToSellerCommandValidator.cs
+++ b/src/Auctionify.Application/Features/Rates/Commands/AddRateToSeller/AddRateToSellerCommandValidator.cs
@@ -83,7 +83,10 @@ namespace Auctionify.Application.Features.Rates.Commands.AddRateToSeller
 								cancellationToken: cancellationToken
 							);
 
-							if (ratings.Items.Count < 1 && !ratings.Items.Any(item => item.SenderId == lot.BuyerId))
+							if (
+								ratings.Items.Count <= 2
+								&& !ratings.Items.Any(item => item.SenderId == lot.BuyerId)
+							)
 							{
 								return true;
 							}

--- a/src/Auctionify.Application/Features/Rates/Profiles/MappingProfiles.cs
+++ b/src/Auctionify.Application/Features/Rates/Profiles/MappingProfiles.cs
@@ -1,15 +1,16 @@
 ﻿using Auctionify.Application.Common.DTOs;
-using Auctionify.Application.Features.Rates.Queries.GetReceiverRates;
-using Auctionify.Application.Features.Rates.Queries.GetSenderRates;
 using Auctionify.Application.Features.Rates.Commands.AddRateToBuyer;
 using Auctionify.Application.Features.Rates.Commands.AddRateToSeller;
+using Auctionify.Application.Features.Rates.Queries.GetReceiverRates;
+using Auctionify.Application.Features.Rates.Queries.GetSenderRate;
+using Auctionify.Application.Features.Rates.Queries.GetSenderRates;
 using Auctionify.Core.Entities;
 using Auctionify.Core.Persistence.Paging;
 using AutoMapper;
 
 namespace Auctionify.Application.Features.Rates.Profiles
 {
-    public class MappingProfiles : Profile
+	public class MappingProfiles : Profile
 	{
 		public MappingProfiles()
 		{
@@ -19,6 +20,7 @@ namespace Auctionify.Application.Features.Rates.Profiles
 			CreateMap<IPaginate<Rate>, GetListResponseDto<GetAllReceiverRatesResponse>>().ReverseMap();
 			CreateMap<Rate, AddRateToBuyerResponse>().ReverseMap();
 			CreateMap<Rate, AddRateToSellerResponse>().ReverseMap();
+			CreateMap<Rate, GetSenderRateResponse>().ReverseMap();
 		}
 	}
 }

--- a/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateQuery.cs
+++ b/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateQuery.cs
@@ -1,0 +1,64 @@
+﻿using Auctionify.Application.Common.Interfaces;
+using Auctionify.Application.Common.Interfaces.Repositories;
+using Auctionify.Application.Common.Options;
+using AutoMapper;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using User = Auctionify.Core.Entities.User;
+
+namespace Auctionify.Application.Features.Rates.Queries.GetSenderRate
+{
+	public class GetSenderRateQuery : IRequest<GetSenderRateResponse>
+	{
+		public int LotId { get; set; }
+	}
+
+	public class GetSenderRateQueryHandler
+		: IRequestHandler<GetSenderRateQuery, GetSenderRateResponse>
+	{
+		private readonly ICurrentUserService _currentUserService;
+		private readonly UserManager<User> _userManager;
+		private readonly IMapper _mapper;
+		private readonly IRateRepository _rateRepository;
+		private readonly AzureBlobStorageOptions _azureBlobStorageOptions;
+		private readonly IBlobService _blobService;
+
+		public GetSenderRateQueryHandler(
+			ICurrentUserService currentUserService,
+			UserManager<User> userManager,
+			IMapper mapper,
+			IRateRepository rateRepository,
+			IOptions<AzureBlobStorageOptions> azureBlobStorageOptions,
+			IBlobService blobService
+		)
+		{
+			_currentUserService = currentUserService;
+			_userManager = userManager;
+			_mapper = mapper;
+			_rateRepository = rateRepository;
+			_azureBlobStorageOptions = azureBlobStorageOptions.Value;
+			_blobService = blobService;
+		}
+
+		public async Task<GetSenderRateResponse> Handle(
+			GetSenderRateQuery request,
+			CancellationToken cancellationToken
+		)
+		{
+			var user = await _userManager.Users.FirstOrDefaultAsync(
+				u => u.Email == _currentUserService.UserEmail! && !u.IsDeleted,
+				cancellationToken: cancellationToken
+			);
+
+			var senderRate = await _rateRepository.GetAsync(
+				predicate: r => r.SenderId == user.Id && r.LotId == request.LotId,
+				enableTracking: false
+			);
+
+			return _mapper.Map<GetSenderRateResponse>(senderRate);
+
+		}
+	}
+}

--- a/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateResponse.cs
+++ b/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateResponse.cs
@@ -1,0 +1,8 @@
+﻿using Auctionify.Application.Features.Rates.BaseQueyModels;
+
+namespace Auctionify.Application.Features.Rates.Queries.GetSenderRate
+{
+	public class GetSenderRateResponse : GetAllRates
+	{
+	}
+}

--- a/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateResponse.cs
+++ b/src/Auctionify.Application/Features/Rates/Queries/GetSenderRate/GetSenderRateResponse.cs
@@ -1,8 +1,10 @@
-﻿using Auctionify.Application.Features.Rates.BaseQueyModels;
+﻿using Auctionify.Application.Common.DTOs;
+using Auctionify.Application.Features.Rates.BaseQueyModels;
 
 namespace Auctionify.Application.Features.Rates.Queries.GetSenderRate
 {
 	public class GetSenderRateResponse : GetAllRates
 	{
+		public UserDto Sender { get; set; }
 	}
 }

--- a/src/Auctionify.Core/Entities/Lot.cs
+++ b/src/Auctionify.Core/Entities/Lot.cs
@@ -42,8 +42,6 @@ namespace Auctionify.Core.Entities
 
 		public virtual ICollection<Rate> Rates { get; set; }
 
-		public int? RateId { get; set; }
-
 		public virtual ICollection<Bid> Bids { get; set; }
 	}
 }

--- a/src/Auctionify.Infrastructure/Migrations/20240214124234_RateIdRemovalFromLotTable.Designer.cs
+++ b/src/Auctionify.Infrastructure/Migrations/20240214124234_RateIdRemovalFromLotTable.Designer.cs
@@ -4,6 +4,7 @@ using Auctionify.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Auctionify.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240214124234_RateIdRemovalFromLotTable")]
+    partial class RateIdRemovalFromLotTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Auctionify.Infrastructure/Migrations/20240214124234_RateIdRemovalFromLotTable.cs
+++ b/src/Auctionify.Infrastructure/Migrations/20240214124234_RateIdRemovalFromLotTable.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Auctionify.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RateIdRemovalFromLotTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RateId",
+                table: "Lots");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RateId",
+                table: "Lots",
+                type: "int",
+                nullable: true);
+        }
+    }
+}

--- a/src/Auctionify.Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/src/Auctionify.Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -529,7 +529,7 @@ namespace Auctionify.Infrastructure.Persistence
                        ,[CreationDate]
                        ,[ModificationDate])
                  VALUES
-                       (3, 1, 1, 1, 1, 'Sample Lot 1', 'This is a sample lot description for Lot 1.', 100.00, '2023-10-12 10:00:00', '2023-10-15 15:00:00', '2023-10-12 09:00:00', '2023-10-12 09:00:00'),
+                       (3, 1, 4, 1, 1, 'Sample Lot 1', 'This is a sample lot description for Lot 1.', 100.00, '2023-10-12 10:00:00', '2023-10-15 15:00:00', '2023-10-12 09:00:00', '2023-10-12 09:00:00'),
                        (3, 2, 5, 2, 1, 'Sample Lot 2', 'This is a sample lot description for Lot 2.', 150.00, '2023-10-13 11:00:00', '2023-10-16 16:00:00', '2023-10-13 10:00:00', '2023-10-13 10:00:00'),
                        (3, 2, 4, 3, 1, 'Sample Lot 3', 'This is a sample lot description for Lot 3.', 200.00, '2023-10-14 12:00:00', '2023-10-17 17:00:00', '2023-10-14 11:00:00', '2023-10-14 11:00:00')
                      "

--- a/src/Auctionify.Infrastructure/Persistence/ApplicationDbContextInitializer.cs
+++ b/src/Auctionify.Infrastructure/Persistence/ApplicationDbContextInitializer.cs
@@ -161,7 +161,47 @@ namespace Auctionify.Infrastructure.Persistence
 
 				var jewelryCategory = _context.Categories.Add(new Category { Name = "Jewelry" });
 
+				var carsCategory = _context.Categories.Add(new Category { Name = "Cars" });
+
 				await _context.SaveChangesAsync();
+
+				_context.Categories.AddRange(
+					new Category
+					{
+						Name = "Motorcycles",
+						ParentCategoryId = carsCategory.Entity.Id
+					},
+					new Category { Name = "Trucks", ParentCategoryId = carsCategory.Entity.Id },
+					new Category { Name = "Boats", ParentCategoryId = carsCategory.Entity.Id },
+					new Category { Name = "Aircraft", ParentCategoryId = carsCategory.Entity.Id },
+					new Category { Name = "RVs", ParentCategoryId = carsCategory.Entity.Id },
+					new Category
+					{
+						Name = "Commercial Vehicles",
+						ParentCategoryId = carsCategory.Entity.Id
+					},
+					new Category { Name = "Trailers", ParentCategoryId = carsCategory.Entity.Id },
+					new Category
+					{
+						Name = "Classic Cars",
+						ParentCategoryId = carsCategory.Entity.Id
+					},
+					new Category
+					{
+						Name = "Modern Cars",
+						ParentCategoryId = carsCategory.Entity.Id
+					},
+					new Category
+					{
+						Name = "Collectible Cars",
+						ParentCategoryId = carsCategory.Entity.Id
+					},
+					new Category
+					{
+						Name = "Other Vehicles",
+						ParentCategoryId = carsCategory.Entity.Id
+					}
+				);
 
 				_context.Categories.AddRange(
 					new Category
@@ -486,13 +526,12 @@ namespace Auctionify.Infrastructure.Persistence
                        ,[StartingPrice]
                        ,[StartDate]
                        ,[EndDate]
-                       ,[RateId]
                        ,[CreationDate]
                        ,[ModificationDate])
                  VALUES
-                       (3, 1, 1, 1, 1, 'Sample Lot 1', 'This is a sample lot description for Lot 1.', 100.00, '2023-10-12 10:00:00', '2023-10-15 15:00:00', 6, '2023-10-12 09:00:00', '2023-10-12 09:00:00'),
-                       (3, 2, 5, 2, 1, 'Sample Lot 2', 'This is a sample lot description for Lot 2.', 150.00, '2023-10-13 11:00:00', '2023-10-16 16:00:00', 7, '2023-10-13 10:00:00', '2023-10-13 10:00:00'),
-                       (3, 2, 1, 3, 1, 'Sample Lot 3', 'This is a sample lot description for Lot 3.', 200.00, '2023-10-14 12:00:00', '2023-10-17 17:00:00', 8, '2023-10-14 11:00:00', '2023-10-14 11:00:00')
+                       (3, 1, 1, 1, 1, 'Sample Lot 1', 'This is a sample lot description for Lot 1.', 100.00, '2023-10-12 10:00:00', '2023-10-15 15:00:00', '2023-10-12 09:00:00', '2023-10-12 09:00:00'),
+                       (3, 2, 5, 2, 1, 'Sample Lot 2', 'This is a sample lot description for Lot 2.', 150.00, '2023-10-13 11:00:00', '2023-10-16 16:00:00', '2023-10-13 10:00:00', '2023-10-13 10:00:00'),
+                       (3, 2, 4, 3, 1, 'Sample Lot 3', 'This is a sample lot description for Lot 3.', 200.00, '2023-10-14 12:00:00', '2023-10-17 17:00:00', '2023-10-14 11:00:00', '2023-10-14 11:00:00')
                      "
 				);
 

--- a/tests/Auctionify.UnitTests/EntitiesSeeding.cs
+++ b/tests/Auctionify.UnitTests/EntitiesSeeding.cs
@@ -35,6 +35,12 @@ namespace Auctionify.UnitTests
 					},
 					StartingPrice = 100,
 					SellerId = 1,
+					Seller = new User
+					{
+						Id = 1,
+						UserName = "TestUserName",
+						Email = "test@email.com"
+					},
 					BuyerId = 2,
 					CategoryId = 1,
 					CurrencyId = 1,
@@ -58,6 +64,12 @@ namespace Auctionify.UnitTests
 					},
 					StartingPrice = 100,
 					SellerId = 1,
+					Seller = new User
+					{
+						Id = 1,
+						UserName = "TestUserName",
+						Email = "test@email.com"
+					},
 					BuyerId = 2,
 					CategoryId = 1,
 					CurrencyId = 1,
@@ -81,6 +93,12 @@ namespace Auctionify.UnitTests
 					},
 					StartingPrice = 100,
 					SellerId = 1,
+					Seller = new User
+					{
+						Id = 1,
+						UserName = "TestUserName",
+						Email = "test@email.com"
+					},
 					BuyerId = 2,
 					CategoryId = 1,
 					CurrencyId = 1,
@@ -103,6 +121,12 @@ namespace Auctionify.UnitTests
 					},
 					StartingPrice = 100,
 					SellerId = 2,
+					Seller = new User
+					{
+						Id = 2,
+						UserName = "TestUserName",
+						Email = "test@email.com"
+					},
 					BuyerId = 2,
 					CategoryId = 1,
 					CurrencyId = 1,

--- a/tests/Auctionify.UnitTests/GetLotByIdTests/GetLotByIdTests.cs
+++ b/tests/Auctionify.UnitTests/GetLotByIdTests/GetLotByIdTests.cs
@@ -37,6 +37,7 @@ namespace Auctionify.UnitTests.GetLotByIdTests
 				ctx => ctx.Files,
 				mockDbContext
 			);
+
 			var blobStorageOptionsMock = new Mock<IOptions<AzureBlobStorageOptions>>();
 			var configuration = new MapperConfiguration(
 				cfg =>


### PR DESCRIPTION
### Where

[NL-173 Fix rate button and Rate Fixes](https://jjbcapital.atlassian.net/browse/NL-173)
[NL-175 Sprint 9 BugFixes](https://jjbcapital.atlassian.net/browse/NL-175)

### What

The goal of this changes is to improve the design (style) for rate button in lot profile page and adding a new functionality that if user has already rated the lot, then we need to show his rate for the auction instead of rate button.

### How

Implemented everything specified in the task, and fixed other bugs that I noticed in FE and BE respectively. 
Observe images of enhancement:

(the same for buyer) before rating:
![image](https://github.com/U6D5T4/Auctionify/assets/89701590/22f591e1-a3fc-42a7-908f-bb4d1d6dc9b0)


after current user (buyer or seller rated the auction):
![image](https://github.com/U6D5T4/Auctionify/assets/89701590/2513d910-ecd4-4f44-9391-4558023bd37d)


### Affected Area

Auctionify.API.Controllers.ClientApp
Auctionify.Infrastructure (for migration (table fixes were applied for lot entity))

### PR Checklist

_Build_

- [x] Build Succeeded

_Unit Tests_

- [x] All Tests Passed, 0 Ignored, 0 Failed
