### PR TITLE
[186] - Create a page for Active lots of seller

### DIFF
--- a/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.html
@@ -1,0 +1,13 @@
+<h2 class="active-lots-container__title">My active lots</h2>
+<div *ngIf="activeLots.length > 0">
+    <ul class="active-lots-container__list">
+        <li *ngFor="let item of activeLots">
+            <app-lot-item
+                class="active-lots-container__lot-item"
+                [lot]="item"
+                [isUserBuyer]="false"
+            ></app-lot-item>
+        </li>
+    </ul>
+</div>
+<p *ngIf="!activeLots.length">You do not have any active lots!</p>

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.scss
@@ -1,0 +1,18 @@
+.active-lots-container {
+    &__title {
+        font-size: 32px;
+        font-weight: 700;
+        line-height: 40px;
+        text-align: left;
+        margin-bottom: 40px;
+        margin-top: 24px;
+    }
+
+    &__list {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 8px;
+        row-gap: 12px;
+        list-style: none;
+    }
+}

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.spec.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActiveLotsComponent } from './active-lots.component';
+
+describe('ActiveLotsComponent', () => {
+  let component: ActiveLotsComponent;
+  let fixture: ComponentFixture<ActiveLotsComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ActiveLotsComponent]
+    });
+    fixture = TestBed.createComponent(ActiveLotsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/active-lots/active-lots.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import {
+    Client,
+    FilterResponse,
+    FilteredLotModel,
+    PageRequest,
+} from 'src/app/web-api-client';
+
+@Component({
+    selector: 'app-active-lots',
+    templateUrl: './active-lots.component.html',
+    styleUrls: ['./active-lots.component.scss'],
+})
+export class ActiveLotsComponent implements OnInit {
+    activeLots: FilteredLotModel[] = [];
+    filterResponse!: FilterResponse;
+
+    constructor(private apiClient: Client) {}
+
+    ngOnInit(): void {
+        const pageRequest: PageRequest = {
+            PageIndex: 0,
+            PageSize: 500,
+        };
+        this.apiClient.getAllActiveLotsForSeller(pageRequest).subscribe({
+            next: (result) => {
+                this.filterResponse = result;
+                this.activeLots = result.items;
+            },
+        });
+    }
+}

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.html
@@ -75,7 +75,6 @@
         <app-transactions
             [transactionsCount]="3"
             [showHeader]="false"
-            class="left-align"
         ></app-transactions>
     </section>
     <section class="lots-section">

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.scss
@@ -62,7 +62,7 @@
     }
 
     &-main {
-        padding: 40px 0;
+        padding: 20px 0;
         display: flex;
         flex-direction: column;
         gap: 40px;

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.scss
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/dashboard/dashboard.component.scss
@@ -62,8 +62,7 @@
     }
 
     &-main {
-        padding: 40px;
-        padding-top: 24px;
+        padding: 40px 0;
         display: flex;
         flex-direction: column;
         gap: 40px;
@@ -74,6 +73,7 @@
         justify-content: space-between;
         padding-top: 40px;
         width: 100%;
+        max-width: 1400px;
     }
 
     &__transactions-title {
@@ -114,11 +114,5 @@
 }
 
 .transactions {
-    padding-top: 32px;
-
-    &.left-align {
-        app-transactions {
-            text-align: left;
-        }
-    }
+    max-width: 1400px;
 }

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/seller-routing.module.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/seller-routing.module.ts
@@ -2,6 +2,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { CreateLotComponent } from './create-lot/create-lot.component';
 import { NgModule } from '@angular/core';
+import { ActiveLotsComponent } from './active-lots/active-lots.component';
 
 const sellerRoutes: Routes = [
     {
@@ -21,6 +22,11 @@ const sellerRoutes: Routes = [
     {
         path: 'update-lot/:id',
         component: CreateLotComponent,
+        pathMatch: 'full',
+    },
+    {
+        path: 'active-lots',
+        component: ActiveLotsComponent,
         pathMatch: 'full',
     },
 ];

--- a/src/Auctionify.API/ClientApp/src/app/components/seller/seller.module.ts
+++ b/src/Auctionify.API/ClientApp/src/app/components/seller/seller.module.ts
@@ -20,6 +20,7 @@ import { DashboardActiveLotsComponent } from './components/dashboard-active-lots
 import { UiElementsModule } from 'src/app/ui-elements/ui-elements.module';
 import { GeneralModule } from '../general/general.module';
 import { DashboardDraftLotsComponent } from './components/dashboard-draft-lots/dashboard-draft-lots.component';
+import { ActiveLotsComponent } from './active-lots/active-lots.component';
 
 @NgModule({
     declarations: [
@@ -30,6 +31,7 @@ import { DashboardDraftLotsComponent } from './components/dashboard-draft-lots/d
         DashboardComponent,
         DashboardActiveLotsComponent,
         DashboardDraftLotsComponent,
+        ActiveLotsComponent,
     ],
     imports: [
         CommonModule,

--- a/src/Auctionify.API/ClientApp/src/app/layout/navbar-seller/navbar-seller.component.html
+++ b/src/Auctionify.API/ClientApp/src/app/layout/navbar-seller/navbar-seller.component.html
@@ -37,6 +37,7 @@
                     </button>
                     <button
                         mat-flat-button
+                        [routerLink]="['/seller/active-lots']"
                         routerLinkActive="mat-primary"
                         color="white"
                     >


### PR DESCRIPTION
### Where

[NL-186 Create a page for Active lots of seller](https://jjbcapital.atlassian.net/browse/NL-186)

### What

The goal is to create a page of seller active lots, there is a button in seller navbar but it doesn't work (no page for that)

### How

Created a page for that button, so that seller could see his/her active lots.

The following is the sample photo of the result:

![image](https://github.com/U6D5T4/Auctionify/assets/89701590/fd2c5231-5fe8-40a5-82f6-90fd69fc0069)


### Affected Area

Auctionify.API.ClientApp (only FE)

### PR Checklist

_Build_

- [x] Build Succeeded

_Unit Tests_

- [x] All Tests Passed, 0 Ignored, 0 Failed
